### PR TITLE
Corrected typo in the PID equation

### DIFF
--- a/docs/src/controls.md
+++ b/docs/src/controls.md
@@ -6,7 +6,7 @@ we build upon `simulate` to simulate feedback and feedforward control systems.
 
 we express PID controller transfer functions in the form:
 
-$$g_c(s)=K_c \left[1+\frac{1}{\tau_I}+\tau_D s \frac{1}{\tau_D \alpha s + 1}\right]$$
+$$g_c(s)=K_c \left[1+\frac{1}{\tau_I s}+\tau_D s \frac{1}{\tau_D \alpha s + 1}\right]$$
 
 where $\alpha$ characterizes the derivative filter. this controller function function governs the controller output in response to the input error signal.
 


### PR DESCRIPTION
The `s` was missing in the I part of the PID transfer function, the first one of the page.

PS. This is my first time I'm doing a pull request. I just hope I'm doing it right.